### PR TITLE
use kubernetes==7.0.0, because 6.0.0 does not work with Python 3.7.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 boto3==1.5.12
 pytest==3.3.2
 flake8==3.4.1
-kubernetes==6.0.0
+kubernetes==7.0.0


### PR DESCRIPTION
Python 3.7 introduced the "async" keyword which conflicts with a local variable name in the Kubernetes Python package. Fixed in 7.0.0.