### PR TITLE
add --sqs-queue-name option...

### DIFF
--- a/k8s-sqs-autoscaler
+++ b/k8s-sqs-autoscaler
@@ -10,6 +10,9 @@ if __name__ == '__main__':
     parser.add_option("--sqs-queue-url",
                       dest="sqs_queue_url",
                       help="SQS Queue URL")
+    parser.add_option("--sqs-queue-name",
+                      dest="sqs_queue_name",
+                      help="SQS Queue Name")
     parser.add_option("--kubernetes-deployment",
                       dest="kubernetes_deployment",
                       help="")
@@ -57,8 +60,8 @@ if __name__ == '__main__':
 
     (options, args) = parser.parse_args()
 
-    if not options.sqs_queue_url:
-        parser.error('SQS_QUEUE_URL not given')
+    if not (options.sqs_queue_url or options.sqs_queue_name):
+        parser.error('SQS_QUEUE_URL / SQS_QUEUE_NAME not given')
     if not options.kubernetes_deployment:
         parser.error('KUBERNETES_DEPLOYMENT not given')
     if not options.aws_region:

--- a/sqs/sqs.py
+++ b/sqs/sqs.py
@@ -14,6 +14,11 @@ class SQSPoller:
     def __init__(self, options):
         self.options = options
         self.sqs_client = boto3.client('sqs')
+
+        if not self.options.sqs_queue_url:
+            # derive the URL from the queue name
+            self.options.sqs_queue_url = self.sqs_client.get_queue_url(QueueName=self.options.sqs_queue_name)['QueueUrl']
+
         config.load_incluster_config()
         self.extensions_v1_beta1 = client.ExtensionsV1beta1Api()
         self.last_scale_up_time = time()


### PR DESCRIPTION
...to identify the SQS queue by name instead of by URL.

This avoids the need to hard-code the AWS account ID into an environment variable. Instead we can fetch the queue URL using the SQS API via implicit IAM credentials.

The existing --sqs-queue-url option takes priority, if present, to preserve compatibility.
