### PR TITLE
add --kubernetes-deployment-selector option

### DIFF
--- a/k8s-sqs-autoscaler
+++ b/k8s-sqs-autoscaler
@@ -12,7 +12,10 @@ if __name__ == '__main__':
                       help="SQS Queue URL")
     parser.add_option("--kubernetes-deployment",
                       dest="kubernetes_deployment",
-                      help="")
+                      help="Name of the Deployment to control")
+    parser.add_option("--kubernetes-deployment-selector",
+                      dest="kubernetes_deployment_selector",
+                      help="Label selector to find the Deployment to control. Defaults to 'app=KUBERNETES_DEPLOYMENT' if not specified.")
     parser.add_option("--kubernetes-namespace",
                       dest="kubernetes_namespace",
                       help="")

--- a/sqs/sqs.py
+++ b/sqs/sqs.py
@@ -70,7 +70,11 @@ class SQSPoller:
 
     def deployment(self):
         logger.debug("loading deployment: {} from namespace: {}".format(self.options.kubernetes_deployment, self.options.kubernetes_namespace))
-        deployments = self.extensions_v1_beta1.list_namespaced_deployment(self.options.kubernetes_namespace, label_selector="app={}".format(self.options.kubernetes_deployment))
+        if self.options.kubernetes_deployment_selector:
+            selector = self.options.kubernetes_deployment_selector
+        else:
+            selector = "app={}".format(self.options.kubernetes_deployment)
+        deployments = self.extensions_v1_beta1.list_namespaced_deployment(self.options.kubernetes_namespace, label_selector=selector)
         return deployments.items[0]
 
     def update_deployment(self, deployment):


### PR DESCRIPTION
The current code assumes that the Deployment you are controlling has an "app=..." label that exactly matches the Deployment resource name.

In my particular cluster, this is not the case, so we need another way for the list_namespaced_deployment() query to find the deployment.

This option allows you to override the "app=..." label query with an arbitrary label query.
e.g. in my case I use
`--kubernetes-deployment-selector=app.kubernetes.io/component=my-deployment-to-control`