### PR TITLE
Use AppsV1Api to be compatible with kubernetes 1.16+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.8.5
 WORKDIR /usr/src/app
 
 COPY scripts/dependencies.sh /tmp/dependencies.sh

--- a/k8s-sqs-autoscaler
+++ b/k8s-sqs-autoscaler
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S python3 -u
 
 from optparse import OptionParser
 from sqs import sqs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 boto3==1.5.12
 pytest==3.3.2
 flake8==3.4.1
-kubernetes==6.0.0
+kubernetes==7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 boto3==1.5.12
 pytest==3.3.2
 flake8==3.4.1
-kubernetes==7.0.0
+kubernetes==11.0.0

--- a/sqs/sqs.py
+++ b/sqs/sqs.py
@@ -97,4 +97,5 @@ def run(options):
     poll_period is set as as part of k8s deployment env variable
     sqs_queue_url is set as as part of k8s deployment env variable
     """
+    logger.info("Starting autoscaler")
     SQSPoller(options).run()

--- a/sqs/sqs.py
+++ b/sqs/sqs.py
@@ -4,18 +4,19 @@ from time import sleep, time
 from logs.log import logger
 from kubernetes import client, config
 
+
 class SQSPoller:
 
     options = None
     sqs_client = None
-    extensions_v1_beta1 = None
+    apps_v1 = None
     last_message_count = None
 
     def __init__(self, options):
         self.options = options
         self.sqs_client = boto3.client('sqs')
         config.load_incluster_config()
-        self.extensions_v1_beta1 = client.ExtensionsV1beta1Api()
+        self.apps_v1 = client.AppsV1Api()
         self.last_scale_up_time = time()
         self.last_scale_down_time = time()
 
@@ -26,11 +27,10 @@ class SQSPoller:
         )
         return int(response['Attributes']['ApproximateNumberOfMessages'])
 
-
     def poll(self):
         message_count = self.message_count()
         t = time()
-        if  message_count >= self.options.scale_up_messages:
+        if message_count >= self.options.scale_up_messages:
             if t - self.last_scale_up_time > self.options.scale_up_cool_down:
                 self.scale_up()
                 self.last_scale_up_time = t
@@ -69,23 +69,28 @@ class SQSPoller:
             logger.info("Min pods reached")
 
     def deployment(self):
-        logger.debug("loading deployment: {} from namespace: {}".format(self.options.kubernetes_deployment, self.options.kubernetes_namespace))
-        deployments = self.extensions_v1_beta1.list_namespaced_deployment(self.options.kubernetes_namespace, label_selector="app={}".format(self.options.kubernetes_deployment))
+        logger.debug("loading deployment: {} from namespace: {}".format(
+            self.options.kubernetes_deployment, self.options.kubernetes_namespace))
+        deployments = self.apps_v1.list_namespaced_deployment(
+            self.options.kubernetes_namespace, label_selector="app={}".format(self.options.kubernetes_deployment))
         return deployments.items[0]
 
     def update_deployment(self, deployment):
         # Update the deployment
-        api_response = self.extensions_v1_beta1.patch_namespaced_deployment(
+        api_response = self.apps_v1.patch_namespaced_deployment(
             name=self.options.kubernetes_deployment,
             namespace=self.options.kubernetes_namespace,
             body=deployment)
-        logger.debug("Deployment updated. status='%s'" % str(api_response.status))
+        logger.debug("Deployment updated. status='%s'" %
+                     str(api_response.status))
 
     def run(self):
         options = self.options
-        logger.debug("Starting poll for {} every {}s".format(options.sqs_queue_url, options.poll_period))
+        logger.debug("Starting poll for {} every {}s".format(
+            options.sqs_queue_url, options.poll_period))
         while True:
             self.poll()
+
 
 def run(options):
     """


### PR DESCRIPTION
Support for `ExtensionsV1beta1Api` has been removed in kubernetes 1.16.  Migrate to use `AppsV1Api` instead.